### PR TITLE
fix: Explicitly use ES6 modules

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "ES2022",
-        "module": "commonjs",
+        "module": "ES2022",
         "lib": ["ES2022"],
         "outDir": "./dist",
         "strict": true,
@@ -9,7 +9,7 @@
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "resolveJsonModule": true,
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "baseUrl": ".",
         "paths": {
             "@shared/*": ["../shared/*"]

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,4 +1,5 @@
 {
     "name": "@riffbit/shared",
-    "version": "0.1"
+    "version": "0.1",
+    "type": "module"
 }

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "ES2022",
-        "module": "commonjs",
+        "module": "ES2022",
         "strict": true,
         "skipLibCheck": true
     }


### PR DESCRIPTION
## Description
Update configs to explicitly use ES6 modules.
Some mismatch with commonjs was causing questionRepository to not import default exports correctly.

## Related Issue
None

## Type of Change
- [ ] Feature
- [ ] Refactor
- [x] Fix
- [ ] Other

## Checklist
- [ ] Documentation added
- [ ] Tests added/updated
- [x] Manually tested functionality