### PR TITLE
refactor: #41 Update id not found error handling

### DIFF
--- a/server/src/controllers/generationController.ts
+++ b/server/src/controllers/generationController.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import QuestionNotFoundError from "src/errors/QuestionNotFoundError";
 import logger from "src/utils/logger";
 
 import * as generationService from "../services/generationService";
@@ -23,16 +24,13 @@ export async function generateSimilarQuestion(req: Request, res: Response) {
         }
 
         const question = await questionService.getQuestionById(id);
-
-        if (!question) {
-            res.status(404).json({ error: `Question with ID ${id} not found` });
-            return;
-        }
-
         const similarQuestion = await generationService.generateSimilarQuestion(question.text);
 
         res.json(similarQuestion);
     } catch (error) {
+        if (error instanceof QuestionNotFoundError) {
+            return res.status(error.status).json({ error: error.message });
+        }
         logger.error({ error }, `Failed to generate question ${req.params.id}`);
         res.status(500).json({ error: "Failed to generate question" });
     }

--- a/server/src/controllers/questionController.test.ts
+++ b/server/src/controllers/questionController.test.ts
@@ -1,3 +1,4 @@
+import QuestionNotFoundError from "src/errors/QuestionNotFoundError";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import * as questionService from "../services/questionService";
@@ -40,7 +41,9 @@ describe("questionController", () => {
         });
 
         test("returns 404 when not found", async () => {
-            vi.spyOn(questionService, "getQuestionById").mockResolvedValue(undefined as any);
+            vi.spyOn(questionService, "getQuestionById").mockRejectedValue(
+                new QuestionNotFoundError(5)
+            );
             const req = { params: { id: "5" } } as any;
             const res = makeRes();
 
@@ -48,7 +51,7 @@ describe("questionController", () => {
 
             expect(res.status).toHaveBeenCalledWith(404);
             expect(res.status().json).toHaveBeenCalledWith({
-                error: "Question with ID 5 not found",
+                error: 'Question with id "5" not found',
             });
         });
 

--- a/server/src/controllers/questionController.ts
+++ b/server/src/controllers/questionController.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import QuestionNotFoundError from "src/errors/QuestionNotFoundError";
 import logger from "src/utils/logger";
 
 import * as questionService from "../services/questionService";
@@ -36,15 +37,12 @@ export async function getQuestionById(req: Request, res: Response) {
         if (isNaN(id)) {
             return res.status(400).json({ error: "Invalid question ID format" });
         }
-
         const question = await questionService.getQuestionById(id);
-
-        if (question) {
-            res.json(question);
-        } else {
-            res.status(404).json({ error: `Question with ID ${id} not found` });
-        }
+        res.json(question);
     } catch (error) {
+        if (error instanceof QuestionNotFoundError) {
+            return res.status(error.status).json({ error: error.message });
+        }
         logger.error({ error }, `Failed to fetch question with ID ${req.params.id}`);
         res.status(500).json({ error: "Failed to fetch question" });
     }

--- a/server/src/errors/QuestionNotFoundError.ts
+++ b/server/src/errors/QuestionNotFoundError.ts
@@ -1,0 +1,10 @@
+export default class QuestionNotFoundError extends Error {
+    status = 404;
+    id: number;
+
+    constructor(id: number, message?: string) {
+        super(message || `Question with id "${id}" not found`);
+        this.name = "QuestionNotFoundError";
+        this.id = id;
+    }
+}

--- a/server/src/routes/questionRoutes.integration.test.ts
+++ b/server/src/routes/questionRoutes.integration.test.ts
@@ -66,6 +66,7 @@ describe("Question API Routes", () => {
                 .expect("Content-Type", /json/);
 
             expect(response.body.error).toContain("not found");
+            expect(response.body.error).toContain("99999");
         });
 
         it("returns 400 for invalid ID format", async () => {

--- a/server/src/services/questionService.ts
+++ b/server/src/services/questionService.ts
@@ -1,3 +1,5 @@
+import QuestionNotFoundError from "src/errors/QuestionNotFoundError";
+
 import * as questionRepository from "../repositories/questionRepository";
 
 /**
@@ -23,6 +25,9 @@ export async function getAllQuestions() {
  */
 export async function getQuestionById(id: number) {
     const question = await questionRepository.getQuestionById(id);
+    if (!question) {
+        throw new QuestionNotFoundError(id);
+    }
     return question;
 }
 

--- a/server/src/services/questionService.ts
+++ b/server/src/services/questionService.ts
@@ -21,7 +21,7 @@ export async function getAllQuestions() {
 /**
  * Get a question by id.
  * @param id - Numeric question id
- * @returns Promise resolving to the question or undefined if not found
+ * @returns Promise resolving to the question
  */
 export async function getQuestionById(id: number) {
     const question = await questionRepository.getQuestionById(id);
@@ -34,6 +34,7 @@ export async function getQuestionById(id: number) {
 /**
  * Get a random question.
  * @returns Promise resolving to a single randomly selected question
+ * @throws {QuestionNotFoundError} When no question matches the provided ID
  */
 export async function getRandomQuestion() {
     const question = await questionRepository.getRandomQuestion();


### PR DESCRIPTION
## Description
QuestionService now throws a new `QuestionNotFoundError` on unfound id instead of returning undefined

## Related Issue
Closes #41 

## Type of Change
- [ ] Feature
- [x] Refactor
- [ ] Fix
- [ ] Other

## Checklist
- [x] Documentation added
- [x] Tests added/updated
- [x] Manually tested functionality